### PR TITLE
use rwlock, address clippy

### DIFF
--- a/src/models/poll.rs
+++ b/src/models/poll.rs
@@ -50,7 +50,7 @@ impl Poll {
         self.options.push(option);
     }
 
-    pub fn remove_option(&mut self, option: PollOption) {
+    pub fn remove_option(&mut self, option: &PollOption) {
         self.options.retain(|o| o.id != option.id);
     }
 }

--- a/src/models/state.rs
+++ b/src/models/state.rs
@@ -5,11 +5,10 @@ use serde_json::{json, Value};
 use axum::{http::StatusCode, Json};
 use std::collections::BTreeMap;
 
-use super::{AppConfiguration, Poll, PollOption};
+use super::{Poll, PollOption};
 
 pub struct AppState {
     pub polls: BTreeMap<String, Poll>,
-    pub config: AppConfiguration,
 }
 
 pub enum APIError {
@@ -92,7 +91,7 @@ impl TryFrom<serde_json::Value> for NewPollBody {
         let recaptcha_token = value
             .get("recaptcha_token")
             .and_then(Value::as_str)
-            .map(|f| f.to_string());
+            .map(ToString::to_string);
 
         Ok(NewPollBody {
             title: title.to_string(),
@@ -127,13 +126,12 @@ impl TryFrom<serde_json::Value> for PollVoteBody {
         let option = value
             .get("option")
             .and_then(Value::as_u64)
-            .map(u64::from)
             .ok_or(APIError::InvalidRequest)?;
 
         let recaptcha_token = value
             .get("recaptcha_token")
             .and_then(Value::as_str)
-            .map(|f| f.to_string());
+            .map(ToString::to_string);
 
         Ok(PollVoteBody {
             option,

--- a/src/models/view.rs
+++ b/src/models/view.rs
@@ -17,6 +17,7 @@ impl From<&Poll> for PollView {
     fn from(poll: &Poll) -> Self {
         let mut view = PollView {
             title: poll.title.clone(),
+            #[allow(clippy::cast_possible_truncation)]
             option_count: poll.options.len() as u32,
             options: HashMap::new(),
         };

--- a/src/models/voter.rs
+++ b/src/models/voter.rs
@@ -8,6 +8,7 @@ pub struct Voter {
 }
 
 impl Voter {
+    #[must_use]
     pub fn new(ip: String, poll_id: String, option_id: u64) -> Self {
         Voter {
             ip,

--- a/src/routes/create_poll.rs
+++ b/src/routes/create_poll.rs
@@ -1,35 +1,39 @@
 use std::sync::Arc;
 
-use axum::{extract::State, response::Result};
+use axum::{extract::State, response::Result, Extension};
 
 use serde_json::{json, Value};
-use tokio::sync::Mutex;
+use tokio::sync::RwLock;
 
 use crate::{
     functions::recaptcha::Recaptcha,
-    models::{AppState, NewPollBody, Poll},
+    models::{AppConfiguration, AppState, NewPollBody, Poll},
 };
-
 
 use axum::{http::StatusCode, Json};
 
 /// POST /poll
 /// Create a new poll
+///
+/// # Errors
+///
+/// - missing recaptcha token, if enabled
+/// - invalid poll
 pub async fn create_poll(
-    State(state): State<Arc<Mutex<AppState>>>,
+    State(polls): State<Arc<RwLock<AppState>>>,
+    Extension(config): Extension<Arc<AppConfiguration>>,
     Json(body): Json<serde_json::Value>, // it sucks that we can't just do: Json<NewPollBody>,
                                          // because for API servers, we can't control the error response in axum when the deserialize fails
                                          // see more: https://github.com/tokio-rs/axum/issues/1116
 ) -> Result<(StatusCode, Json<Value>)> {
-    let mut guard = state.lock().await;
-
     let body = NewPollBody::try_from(body)?; // instead, we have a TryFrom implementation which throws an APIError
                                              // here, we can control our response when the deserialization fails
 
     if body.recaptcha_token.is_some() {
-        body.verify(&guard.config).await?;
+        body.verify(Arc::clone(&config)).await?;
     }
 
+    let mut guard = polls.write().await;
     let poll = Poll::from(body);
     guard.polls.insert(poll.id.clone(), poll.clone());
 

--- a/src/routes/get_poll.rs
+++ b/src/routes/get_poll.rs
@@ -3,7 +3,7 @@ use std::sync::Arc;
 use axum::{extract::State, response::Result};
 
 use serde_json::{json, Value};
-use tokio::sync::Mutex;
+use tokio::sync::RwLock;
 
 use crate::models::{APIError, AppState, PollView};
 
@@ -11,12 +11,15 @@ use axum::{extract::Path, http::StatusCode, Json};
 
 /// GET /poll/:id
 /// Returns a poll with the given id
+///
+/// # Errors
+///
+/// - missing poll
 pub async fn get_poll(
     Path(id): Path<String>,
-    State(state): State<Arc<Mutex<AppState>>>,
+    State(state): State<Arc<RwLock<AppState>>>,
 ) -> Result<(StatusCode, Json<Value>)> {
-    // let guard = state.read_lock()?;
-    let guard = state.lock().await;
+    let guard = state.read().await;
 
     match guard.polls.get(&id) {
         Some(poll) => {

--- a/src/routes/get_poll_options.rs
+++ b/src/routes/get_poll_options.rs
@@ -3,7 +3,7 @@ use std::sync::Arc;
 use axum::{extract::State, response::Result};
 
 use serde_json::{json, Value};
-use tokio::sync::Mutex;
+use tokio::sync::RwLock;
 
 use crate::models::{APIError, AppState, PollPartialView};
 
@@ -11,11 +11,15 @@ use axum::{extract::Path, http::StatusCode, Json};
 
 /// GET /poll/:id/options
 /// Returns a poll with the given id
+///
+/// # Errors
+///
+/// - missing poll
 pub async fn get_poll_options(
     Path(id): Path<String>,
-    State(state): State<Arc<Mutex<AppState>>>,
+    State(state): State<Arc<RwLock<AppState>>>,
 ) -> Result<(StatusCode, Json<Value>)> {
-    let guard = state.lock().await;
+    let guard = state.read().await;
 
     match guard.polls.get(&id) {
         Some(poll) => {

--- a/src/routes/static_routes.rs
+++ b/src/routes/static_routes.rs
@@ -4,6 +4,11 @@ use axum::http::StatusCode;
 
 /// GET /index.html
 /// Returns a poll with the given id
+///
+/// # Errors
+///
+/// - never. result for axum
+#[allow(clippy::unused_async)]
 pub async fn get_index() -> Result<(StatusCode, Html<String>)> {
     Ok((
         StatusCode::OK,
@@ -13,6 +18,11 @@ pub async fn get_index() -> Result<(StatusCode, Html<String>)> {
 
 /// GET /bundle.js
 /// Returns a poll with the given id
+///
+/// # Errors
+///
+/// - never. result for axum
+#[allow(clippy::unused_async)]
 pub async fn get_bundle() -> Result<(StatusCode, Html<String>)> {
     Ok((
         StatusCode::OK,

--- a/src/routes/vote_poll.rs
+++ b/src/routes/vote_poll.rs
@@ -1,13 +1,13 @@
 use std::sync::Arc;
 
-use axum::{extract::State, http::HeaderMap, response::Result};
+use axum::{extract::State, http::HeaderMap, response::Result, Extension};
 
 use serde_json::{json, Value};
-use tokio::sync::Mutex;
+use tokio::sync::RwLock;
 
 use crate::{
     functions::recaptcha::Recaptcha,
-    models::{APIError, AppState, PollVoteBody, Voter},
+    models::{APIError, AppConfiguration, AppState, PollVoteBody, Voter},
 };
 
 use axum::{extract::Path, http::StatusCode, Json};
@@ -17,23 +17,31 @@ use std::net::SocketAddr;
 
 /// POST /poll/:id/vote
 /// Vote on a poll
+///
+/// # Errors
+///
+/// - missing poll/option
+/// - missing recaptcha token, if enabled
+/// - invalid poll/option
 pub async fn vote_poll(
     ConnectInfo(addr): ConnectInfo<SocketAddr>,
     headers: HeaderMap,
     Path(id): Path<String>,
-    State(state): State<Arc<Mutex<AppState>>>,
+    State(polls): State<Arc<RwLock<AppState>>>,
+    Extension(config): Extension<Arc<AppConfiguration>>,
     Json(body): Json<serde_json::Value>,
 ) -> Result<(StatusCode, Json<Value>)> {
-    let mut guard = state.lock().await;
-
     let body = PollVoteBody::try_from(body)?;
     if body.recaptcha_token.is_some() {
-        body.verify(&guard.config).await?;
+        body.verify(Arc::clone(&config)).await?;
     }
+
+    let mut guard = polls.write().await;
 
     match guard.polls.get_mut(&id) {
         Some(poll) => {
             // the option is the array index of the target option + 1
+            #[allow(clippy::cast_possible_truncation)]
             let option = poll
                 .options
                 .get_mut((body.option - 1) as usize)
@@ -47,9 +55,9 @@ pub async fn vote_poll(
 
             tracing::info!(ip, "Voting on poll");
             let voter = Voter::new(ip, id.clone(), body.option);
-            let voted = option.vote(&voter);
+            let has_voted = option.vote(&voter);
 
-            Ok((StatusCode::OK, Json(json!({"voted": voted}))))
+            Ok((StatusCode::OK, Json(json!({"voted": has_voted}))))
         }
         None => Err(APIError::PollNotFound.into()),
     }


### PR DESCRIPTION
Replaces `Mutex` with `RwLock` for a bit better performance, to avoid locking the entire poll set on reads.

Also moves the `AppConfiguration` out of state, and into a separate extension layer - to remove the need to lock at all to retrieve the application configuration.

Also addresses clippy rules for `clippy::pedantic`